### PR TITLE
fix: oversized messages causes clients to hang/throw exceptions

### DIFF
--- a/web-impl-netty/src/main/java/eu/cloudnetservice/ext/rest/netty/NettyHttpServerInitializer.java
+++ b/web-impl-netty/src/main/java/eu/cloudnetservice/ext/rest/netty/NettyHttpServerInitializer.java
@@ -21,7 +21,7 @@ import eu.cloudnetservice.ext.rest.api.util.HostAndPort;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelInitializer;
 import io.netty5.handler.codec.http.HttpContentCompressor;
-import io.netty5.handler.codec.http.HttpObjectAggregator;
+import io.netty5.handler.codec.http.HttpContentDecompressor;
 import io.netty5.handler.codec.http.HttpRequestDecoder;
 import io.netty5.handler.codec.http.HttpResponseEncoder;
 import io.netty5.handler.ssl.SslContext;
@@ -85,10 +85,11 @@ final class NettyHttpServerInitializer extends ChannelInitializer<Channel> {
     ch.pipeline()
       .addLast("read-timeout-handler", new NettyIdleStateHandler(30))
       .addLast("http-request-decoder", new HttpRequestDecoder())
-      .addLast("http-object-aggregator", new HttpObjectAggregator<>(Short.MAX_VALUE))
+      .addLast("http-request-decompressor", new HttpContentDecompressor())
       .addLast("http-response-encoder", new HttpResponseEncoder())
       .addLast("http-response-compressor", new HttpContentCompressor())
-      .addLast("http-chunk-handler", new ChunkedWriteHandler())
+      .addLast("http-response-chunk-writer", new ChunkedWriteHandler())
+      .addLast("http-object-aggregator", new NettyOversizedClosingHttpAggregator<>(Short.MAX_VALUE))
       .addLast("http-server-handler", new NettyHttpServerHandler(
         this.nettyHttpServer,
         this.listenerAddress,

--- a/web-impl-netty/src/main/java/eu/cloudnetservice/ext/rest/netty/NettyOversizedClosingHttpAggregator.java
+++ b/web-impl-netty/src/main/java/eu/cloudnetservice/ext/rest/netty/NettyOversizedClosingHttpAggregator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019-2024 CloudNetService team & contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package eu.cloudnetservice.ext.rest.netty;
+
+import io.netty5.channel.ChannelHandlerContext;
+import io.netty5.handler.codec.http.DefaultFullHttpResponse;
+import io.netty5.handler.codec.http.HttpContent;
+import io.netty5.handler.codec.http.HttpHeaderNames;
+import io.netty5.handler.codec.http.HttpHeaderValues;
+import io.netty5.handler.codec.http.HttpObjectAggregator;
+import io.netty5.handler.codec.http.HttpRequest;
+import io.netty5.handler.codec.http.HttpResponseStatus;
+import lombok.NonNull;
+
+final class NettyOversizedClosingHttpAggregator<C extends HttpContent<C>> extends HttpObjectAggregator<C> {
+
+  public NettyOversizedClosingHttpAggregator(int maxContentLength) {
+    super(maxContentLength);
+  }
+
+  @Override
+  protected void handleOversizedMessage(@NonNull ChannelHandlerContext ctx, @NonNull Object tooLarge) throws Exception {
+    if (tooLarge instanceof HttpRequest httpRequest) {
+      // always the close the connection when the client sent a too large request body as this leaves
+      // the decoder and this aggregator in a mismatched state which would cause the following request
+      // with a too large body to hand forever
+      var response = new DefaultFullHttpResponse(
+        httpRequest.protocolVersion(),
+        HttpResponseStatus.REQUEST_ENTITY_TOO_LARGE,
+        ctx.bufferAllocator().allocate(0));
+      response.headers()
+        .set(HttpHeaderNames.CONNECTION, HttpHeaderValues.CLOSE)
+        .set(HttpHeaderNames.CONTENT_LENGTH, HttpHeaderValues.ZERO);
+      ctx.writeAndFlush(response).addListener(ignored -> ctx.close());
+    } else {
+      // not a request, use the default handling
+      super.handleOversizedMessage(ctx, tooLarge);
+    }
+  }
+}


### PR DESCRIPTION
The HttpObjectAggregator might return http responses in some cases, such as a too large body content-length being sent to the server. As the http encoder was after this handler in the pipeline, the response couldn't be serialized and an exception was thrown. Furthermore, there seems to be a bug in netty which leaves the request decoder and aggregator in a mismatched state, causing the requests sent after a first request with a too long body to hang forever (if keep-alive is enabled). This is fixed for now by just always closing the connection when a too large body is detected.