### PR TITLE
chore: re-enable response compression

### DIFF
--- a/web-impl-netty/src/main/java/eu/cloudnetservice/ext/rest/netty/NettyHttpServerInitializer.java
+++ b/web-impl-netty/src/main/java/eu/cloudnetservice/ext/rest/netty/NettyHttpServerInitializer.java
@@ -20,6 +20,7 @@ import eu.cloudnetservice.ext.rest.api.config.HttpProxyMode;
 import eu.cloudnetservice.ext.rest.api.util.HostAndPort;
 import io.netty5.channel.Channel;
 import io.netty5.channel.ChannelInitializer;
+import io.netty5.handler.codec.http.HttpContentCompressor;
 import io.netty5.handler.codec.http.HttpContentDecompressor;
 import io.netty5.handler.codec.http.HttpRequestDecoder;
 import io.netty5.handler.codec.http.HttpResponseEncoder;
@@ -91,8 +92,7 @@ final class NettyHttpServerInitializer extends ChannelInitializer<Channel> {
       .addLast("http-request-decoder", new HttpRequestDecoder())
       .addLast("http-request-decompressor", new HttpContentDecompressor())
       .addLast("http-response-encoder", new HttpResponseEncoder())
-      // TODO: re-enable compression when JDK-8357145 is resolved
-      // .addLast("http-response-compressor", new HttpContentCompressor())
+      .addLast("http-response-compressor", new HttpContentCompressor())
       .addLast("http-response-chunk-writer", new ChunkedWriteHandler())
       .addLast("http-object-aggregator", new NettyOversizedClosingHttpAggregator<>(this.maxContentLength))
       .addLast("http-server-handler", new NettyHttpServerHandler(


### PR DESCRIPTION
This is possible again with our custom memory-segment buffers (they are now allocated in the global arena which isn't restricted). Depends on https://github.com/CloudNetService/CloudNet/pull/1655